### PR TITLE
Fix and improve benchmarks 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 /browser.js
 emsdk-portable
 package-lock.json
+
+benchmark/*.csv

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -23,11 +23,10 @@ async function getText() {
 getText().then(txt => {
   const buffer = new TextBuffer()
 
-  console.log('running findWordsWithSubsequence tests...')
+  console.log('\n running findWordsWithSubsequence tests... \n')
 
   const sizes = [ ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
-  const word = "Morocco"
   const test = (word, size) => {
     buffer.setText(txt.slice(0, size[1]))
     const ti = performance.now()
@@ -37,9 +36,11 @@ getText().then(txt => {
     })
   }
 
-  return sizes.reduce((promise, size) => {
-    return promise.then(() => test(word, size))
-  }, Promise.resolve())
+  for (const word of ["Morocco", "Austria", "France", "Liechtenstein", "Republic of the Congo", "Antigua and Barbuda", "Japan"]) {
+    sizes.reduce((promise, size) => {
+      return promise.then(() => test(word, size))
+    }, Promise.resolve())
+  }
 }).then(() => {
-  console.log('finished')
+  console.log('findWordsWithSubsequence tests finished \n')
 })

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -27,13 +27,12 @@ getText().then(async (txt) => {
 
   const sizes = [ ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
-  const test = (word, size) => {
+  const test = async (word, size) => {
     buffer.setText(txt.slice(0, size[1]))
     const ti = performance.now()
-    return buffer.findWordsWithSubsequence(word, '', 100).then(sugs => {
-      const tf = performance.now()
-      console.log(`In ${size[0]} file, time to find "${word}" was: ${' '.repeat(50-word.length-size[0].length)} ${(tf-ti).toFixed(5)} ms`)
-    })
+    await buffer.findWordsWithSubsequence(word, '', 100)
+    const tf = performance.now()
+    console.log(`In ${size[0]} file, time to find "${word}" was: ${' '.repeat(50-word.length-size[0].length)} ${(tf-ti).toFixed(5)} ms`)
   }
   for (const size of sizes) {
     for (const word of ["Morocco", "Austria", "France", "Liechtenstein", "Republic of the Congo", "Antigua and Barbuda", "Japan"]) {

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -5,6 +5,7 @@ const {promisify} = require('util')
 const readFile = promisify(fs.readFile)
 const path = require('path')
 const download = require('download')
+const {performance} = require("perf_hooks")
 
 async function getText() {
   const filePath = path.join(__dirname, '1000000 Sales Records.csv')
@@ -19,8 +20,6 @@ async function getText() {
   return await readFile(filePath)
 }
 
-const timer = size => `Time to find "cat" in ${size} file`
-
 getText().then(txt => {
   const buffer = new TextBuffer()
 
@@ -28,17 +27,18 @@ getText().then(txt => {
 
   const sizes = [['10b', 10], ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
-  const test = size => {
-    const _timer = timer(size[0])
+  const word = "Morocco"
+  const test = (word, size) => {
     buffer.setText(txt.slice(0, size[1]))
-    console.time(_timer)
-    return buffer.findWordsWithSubsequence('cat', '', 100).then(sugs => {
-      console.timeEnd(_timer)
+    const ti = performance.now()
+    return buffer.findWordsWithSubsequence(word, '', 100).then(sugs => {
+      const tf = performance.now()
+      console.log(`Time to find "${word}" in ${size[0]} file: ${(tf-ti).toFixed(5)} ms`)
     })
   }
 
   return sizes.reduce((promise, size) => {
-    return promise.then(() => test(size))
+    return promise.then(() => test(word, size))
   }, Promise.resolve())
 }).then(() => {
   console.log('finished')

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -23,23 +23,31 @@ async function getText() {
 getText().then(async (txt) => {
   const buffer = new TextBuffer()
 
-  console.log('\n running findWordsWithSubsequence tests... \n')
+  console.log('\n running large-text-buffer tests... \n')
 
   const sizes = [ ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
   const test = async (word, size) => {
-    buffer.setText(txt.slice(0, size[1]))
-    const ti = performance.now()
+    const ti2 = performance.now()
     await buffer.findWordsWithSubsequence(word, '', 100)
-    const tf = performance.now()
-    console.log(`In ${size[0]} file, time to find "${word}" was: ${' '.repeat(50-word.length-size[0].length)} ${(tf-ti).toFixed(5)} ms`)
+    const tf2 = performance.now()
+    console.log(`For ${size[0]} file, time to find "${word}" was: ${' '.repeat(50-word.length-size[0].length)} ${(tf2-ti2).toFixed(5)} ms`)
   }
   for (const size of sizes) {
+
+    const bufferText = txt.slice(0, size[1])
+
+    // benchmark buffer.setText
+    const ti1 = performance.now()
+    buffer.setText(bufferText)
+    const tf1 = performance.now()
+    console.log(`For ${size[0]} file, buffer.setText took ${' '.repeat(51-size[0].length)} ${(tf1-ti1).toFixed(5)} ms`)
+
     for (const word of ["Morocco", "Austria", "France", "Liechtenstein", "Republic of the Congo", "Antigua and Barbuda", "Japan"]) {
       await test(word, size)
     }
     console.log('\n')
   }
 }).then(() => {
-  console.log('findWordsWithSubsequence tests finished \n')
+  console.log(' large-text-buffer finished \n')
 })

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -25,7 +25,7 @@ getText().then(txt => {
 
   console.log('running findWordsWithSubsequence tests...')
 
-  const sizes = [['10b', 10], ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
+  const sizes = [ ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
   const word = "Morocco"
   const test = (word, size) => {

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -20,7 +20,7 @@ async function getText() {
   return await readFile(filePath)
 }
 
-getText().then(txt => {
+getText().then(async (txt) => {
   const buffer = new TextBuffer()
 
   console.log('\n running findWordsWithSubsequence tests... \n')
@@ -35,11 +35,11 @@ getText().then(txt => {
       console.log(`In ${size[0]} file, time to find "${word}" was: ${' '.repeat(50-word.length-size[0].length)} ${(tf-ti).toFixed(5)} ms`)
     })
   }
-
-  for (const word of ["Morocco", "Austria", "France", "Liechtenstein", "Republic of the Congo", "Antigua and Barbuda", "Japan"]) {
-    sizes.reduce((promise, size) => {
-      return promise.then(() => test(word, size))
-    }, Promise.resolve())
+  for (const size of sizes) {
+    for (const word of ["Morocco", "Austria", "France", "Liechtenstein", "Republic of the Congo", "Antigua and Barbuda", "Japan"]) {
+      await test(word, size)
+    }
+    console.log('\n')
   }
 }).then(() => {
   console.log('findWordsWithSubsequence tests finished \n')

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -1,33 +1,22 @@
-const http = require('http')
-const fs = require('fs')
-const unzip = require('unzip')
 const { TextBuffer } = require('..')
 
-const unzipper = unzip.Parse()
+const fs = require('fs')
+const {promisify} = require('util')
+const readFile = promisify(fs.readFile)
+const path = require('path')
+const download = require('download')
 
-const getText = () => {
-  return new Promise(resolve => {
-    console.log('fetching text file...')
-    const req = http.get({
-      hostname: 'www.acleddata.com',
-      port: 80,
-      // 51 MB text file
-      path: '/wp-content/uploads/2017/01/ACLED-Version-7-All-Africa-1997-2016_csv_dyadic-file.zip',
-      agent: false
-    }, res => {
-      res
-        .pipe(unzipper)
-        .on('entry', entry => {
-          let data = '';
-          entry.on('data', chunk => data += chunk);
-          entry.on('end', () => {
-            resolve(data)
-          });
-        })
-    })
-
-    req.end()
-  })
+async function getText() {
+  const filePath = path.join(__dirname, '1000000 Sales Records.csv')
+  if (!fs.existsSync(filePath)) {
+    // 122MB file
+    await download(
+      'http://eforexcel.com/wp/wp-content/uploads/2017/07/1000000%20Sales%20Records.zip',
+      __dirname,
+      {extract: true}
+    )
+  }
+  return await readFile(filePath)
 }
 
 const timer = size => `Time to find "cat" in ${size} file`

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -32,7 +32,7 @@ getText().then(txt => {
     const ti = performance.now()
     return buffer.findWordsWithSubsequence(word, '', 100).then(sugs => {
       const tf = performance.now()
-      console.log(`Time to find "${word}" in ${size[0]} file: ${(tf-ti).toFixed(5)} ms`)
+      console.log(`In ${size[0]} file, time to find "${word}" was: ${' '.repeat(50-word.length-size[0].length)} ${(tf-ti).toFixed(5)} ms`)
     })
   }
 

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -26,7 +26,7 @@ getText().then(txt => {
 
   console.log('running findWordsWithSubsequence tests...')
 
-  const sizes = [['10b', 10], ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000]]
+  const sizes = [['10b', 10], ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
   const test = size => {
     const _timer = timer(size[0])

--- a/benchmark/marker-index.benchmark.js
+++ b/benchmark/marker-index.benchmark.js
@@ -1,6 +1,10 @@
 'use strict';
 
+console.log(' running marker-index tests... \n')
+
 const Random = require('random-seed')
+const {performance} = require("perf_hooks")
+
 const {MarkerIndex} = require('..')
 const {traverse, traversalDistance, compare} = require('../test/js/helpers/point-helpers')
 
@@ -41,12 +45,13 @@ function runBenchmark () {
 }
 
 function profileOperations (name, operations) {
-  console.time(name)
+  const ti1 = performance.now()
   for (let i = 0, n = operations.length; i < n; i++) {
     const operation = operations[i]
     markerIndex[operation[0]].apply(markerIndex, operation[1])
   }
-  console.timeEnd(name)
+  const tf1 = performance.now()
+  console.log(`${name} ${' '.repeat(80-name.length)} ${(tf1-ti1).toFixed(3)} ms`)
 }
 
 function enqueueSequentialInsert () {
@@ -118,3 +123,5 @@ function getSplice () {
 }
 
 runBenchmark()
+
+console.log(' \n marker-index finished \n')

--- a/benchmark/text-buffer.benchmark.js
+++ b/benchmark/text-buffer.benchmark.js
@@ -1,4 +1,8 @@
+console.log(' running text-buffer tests... \n')
+
 const assert = require('assert')
+const {performance} = require("perf_hooks")
+
 const {TextBuffer} = require('..')
 
 const text = 'abc def ghi jkl\n'.repeat(1024 * 1024)
@@ -8,14 +12,15 @@ const trialCount = 10
 
 function benchmarkSearch(description, pattern, expectedPosition) {
   let name = `Search for ${description} - TextBuffer`
-  console.time(name)
+  const ti1 = performance.now()
   for (let i = 0; i < trialCount; i++) {
     assert.deepEqual(buffer.findSync(pattern), expectedPosition)
   }
-  console.timeEnd(name)
+  const tf1 = performance.now()
+  console.log(`${name} ${' '.repeat(80-name.length)} ${(tf1-ti1).toFixed(3)} ms`)
 
   name = `Search for ${description} - lines array`
-  console.time(name)
+  const ti2 = performance.now()
   const regex = new RegExp(pattern)
   for (let i = 0; i < trialCount; i++) {
     for (let row = 0, rowCount = lines.length; row < rowCount; row++) {
@@ -32,11 +37,14 @@ function benchmarkSearch(description, pattern, expectedPosition) {
       }
     }
   }
-  console.timeEnd(name)
-  console.log()
+  const tf2 = performance.now()
+  console.log(`${name} ${' '.repeat(80-name.length)} ${(tf2-ti2).toFixed(3)} ms`)
 }
 
 benchmarkSearch('simple non-existent pattern', '\t', null)
 benchmarkSearch('complex non-existent pattern', '123|456|789', null)
 benchmarkSearch('simple existing pattern', 'jkl', {start: {row: 0, column: 12}, end: {row: 0, column: 15}})
 benchmarkSearch('complex existing pattern', 'j\\w+', {start: {row: 0, column: 12}, end: {row: 0, column: 15}})
+
+
+console.log('\n text-buffer finished \n')

--- a/benchmark/text-buffer.benchmark.js
+++ b/benchmark/text-buffer.benchmark.js
@@ -10,7 +10,7 @@ function benchmarkSearch(description, pattern, expectedPosition) {
   let name = `Search for ${description} - TextBuffer`
   console.time(name)
   for (let i = 0; i < trialCount; i++) {
-    assert.deepEqual(buffer.searchSync(pattern), expectedPosition)
+    assert.deepEqual(buffer.findSync(pattern), expectedPosition)
   }
   console.timeEnd(name)
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:node": "mocha test/js/*.js",
     "test:browser": "SUPERSTRING_USE_BROWSER_VERSION=1 mocha test/js/*.js",
     "test": "npm run test:node && npm run test:browser",
-    "benchmark": "node benchmark/marker-index.benchmark.js && node benchmark/large-text-buffer.benchmark.js",
+    "benchmark": "node benchmark/text-buffer.benchmark.js && node benchmark/marker-index.benchmark.js && node benchmark/large-text-buffer.benchmark.js",
     "prepublishOnly": "git submodule update --init --recursive && npm run build:browser",
     "standard": "standard --recursive src test"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:node": "mocha test/js/*.js",
     "test:browser": "SUPERSTRING_USE_BROWSER_VERSION=1 mocha test/js/*.js",
     "test": "npm run test:node && npm run test:browser",
-    "benchmark": "node benchmark/marker-index.benchmark.js",
+    "benchmark": "node benchmark/marker-index.benchmark.js && node benchmark/large-text-buffer.benchmark.js",
     "prepublishOnly": "git submodule update --init --recursive && npm run build:browser",
     "standard": "standard --recursive src test"
   },

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "devDependencies": {
     "chai": "^2.0.0",
+    "download": "^8.0.0",
     "mocha": "^2.3.4",
     "random-seed": "^0.2.0",
     "standard": "^4.5.4",
-    "temp": "^0.8.3",
-    "unzip": "^0.1.11"
+    "temp": "^0.8.3"
   },
   "standard": {
     "global": [


### PR DESCRIPTION
https://github.com/atom/superstring/pull/92

### Description of the change

This fixes all the benchmarks that were broken before this. 
- this includes large-buffer-text and text-buffer benchmarks
- Now, a new csv large file is downloaded from a new link (the old file is not available anymore).
- uses download package instead of non-working unzip package
- makes the test runners async
- runs the tests for different words
- add buffer.setText benchmarks
- uses performance from perf_hooks to measure the time accurately
- pretty print the results


Running this benchmark on my master branch that includes all the improvements from other PRs shows that it is ~30 faster compared to the latest official superstring 🚀  
https://github.com/aminya/superstring

### Verifications
```
npm install
npm run benchmark
```

Sample output:
```

 running text-buffer tests...

Search for simple non-existent pattern - TextBuffer                               26.355 ms
Search for simple non-existent pattern - lines array                              230.589 ms
Search for complex non-existent pattern - TextBuffer                              142.064 ms
Search for complex non-existent pattern - lines array                             214.708 ms
Search for simple existing pattern - TextBuffer                                   0.732 ms
Search for simple existing pattern - lines array                                  0.122 ms
Search for complex existing pattern - TextBuffer                                  0.378 ms
Search for complex existing pattern - lines array                                 0.141 ms

 text-buffer finished

 running marker-index tests...

sequential inserts                                                                115.662 ms
inserts                                                                           154.717 ms
range queries                                                                     1206.237 ms
splices                                                                           8229.161 ms
deletes                                                                           5.935 ms

 marker-index finished


 running large-text-buffer tests...

For 100b file, buffer.setText took                                                 0.06480 ms
For 100b file, time to find "Morocco" was:                                         0.66360 ms
For 100b file, time to find "Austria" was:                                         0.16340 ms
For 100b file, time to find "France" was:                                          0.09890 ms
For 100b file, time to find "Liechtenstein" was:                                   0.07530 ms
For 100b file, time to find "Republic of the Congo" was:                           0.07960 ms
For 100b file, time to find "Antigua and Barbuda" was:                             0.07610 ms
For 100b file, time to find "Japan" was:                                           0.07120 ms


For 1kb file, buffer.setText took                                                  0.05190 ms
For 1kb file, time to find "Morocco" was:                                          0.74130 ms
For 1kb file, time to find "Austria" was:                                          0.17100 ms
For 1kb file, time to find "France" was:                                           0.10220 ms
For 1kb file, time to find "Liechtenstein" was:                                    0.10360 ms
For 1kb file, time to find "Republic of the Congo" was:                            0.10850 ms
For 1kb file, time to find "Antigua and Barbuda" was:                              0.13240 ms
For 1kb file, time to find "Japan" was:                                            0.10670 ms


For 1MB file, buffer.setText took                                                  2.60130 ms
For 1MB file, time to find "Morocco" was:                                          10.84790 ms
For 1MB file, time to find "Austria" was:                                          11.30790 ms
For 1MB file, time to find "France" was:                                           12.05650 ms
For 1MB file, time to find "Liechtenstein" was:                                    10.46920 ms
For 1MB file, time to find "Republic of the Congo" was:                            10.88970 ms
For 1MB file, time to find "Antigua and Barbuda" was:                              10.42880 ms
For 1MB file, time to find "Japan" was:                                            11.04220 ms


For 51MB file, buffer.setText took                                                 238.71440 ms
For 51MB file, time to find "Morocco" was:                                         1061.28110 ms
For 51MB file, time to find "Austria" was:                                         1172.22850 ms
For 51MB file, time to find "France" was:                                          1057.88760 ms
For 51MB file, time to find "Liechtenstein" was:                                   997.99980 ms
For 51MB file, time to find "Republic of the Congo" was:                           1018.14570 ms
For 51MB file, time to find "Antigua and Barbuda" was:                             1047.52090 ms
For 51MB file, time to find "Japan" was:                                           1069.09540 ms


For 119MB file, buffer.setText took                                                326.30900 ms
For 119MB file, time to find "Morocco" was:                                        1352.57120 ms
For 119MB file, time to find "Austria" was:                                        1371.68760 ms
For 119MB file, time to find "France" was:                                         1391.56260 ms
For 119MB file, time to find "Liechtenstein" was:                                  1303.91920 ms
For 119MB file, time to find "Republic of the Congo" was:                          1295.11590 ms
For 119MB file, time to find "Antigua and Barbuda" was:                            1289.58380 ms
For 119MB file, time to find "Japan" was:                                          1324.39010 ms


 large-text-buffer finished

```


### Release Notes
N/A


