### PR TITLE
Explicit constructors

### DIFF
--- a/src/bindings/marker-index-wrapper.h
+++ b/src/bindings/marker-index-wrapper.h
@@ -36,6 +36,6 @@ private:
   static void find_ending_at(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_boundaries_after(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void dump(const Nan::FunctionCallbackInfo<v8::Value> &info);
-  MarkerIndexWrapper(unsigned seed);
   MarkerIndex marker_index;
+  explicit MarkerIndexWrapper(unsigned seed);
 };

--- a/src/bindings/patch-wrapper.cc
+++ b/src/bindings/patch-wrapper.cc
@@ -65,7 +65,7 @@ class ChangeWrapper : public Nan::ObjectWrap {
   }
 
  private:
-  ChangeWrapper(Patch::Change change) : change(change) {}
+  explicit ChangeWrapper(Patch::Change change) : change(change) {}
 
   static void construct(const Nan::FunctionCallbackInfo<Value> &info) {}
 

--- a/src/bindings/patch-wrapper.h
+++ b/src/bindings/patch-wrapper.h
@@ -7,7 +7,7 @@ class PatchWrapper : public Nan::ObjectWrap {
   static v8::Local<v8::Value> from_patch(Patch &&);
 
  private:
-  PatchWrapper(Patch &&patch);
+  explicit PatchWrapper(Patch &&patch);
   static void construct(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void splice(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void splice_old(const Nan::FunctionCallbackInfo<v8::Value> &info);

--- a/src/bindings/point-wrapper.h
+++ b/src/bindings/point-wrapper.h
@@ -12,7 +12,7 @@ public:
   static optional<Point> point_from_js(v8::Local<v8::Value>);
 
 private:
-  PointWrapper(Point point);
+  explicit PointWrapper(Point point);
 
   static void construct(const Nan::FunctionCallbackInfo<v8::Value> &info);
 

--- a/src/bindings/range-wrapper.h
+++ b/src/bindings/range-wrapper.h
@@ -13,7 +13,7 @@ public:
   static optional<Range> range_from_js(v8::Local<v8::Value>);
 
 private:
-  RangeWrapper(Range);
+  explicit RangeWrapper(Range);
 
   static void construct(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void get_start(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -401,7 +401,7 @@ class TextBufferSearcher : public Nan::AsyncWorker {
   Nan::Persistent<Value> argument;
 
 public:
-  TextBufferSearcher(Nan::Callback *completion_callback,
+  explicit TextBufferSearcher(Nan::Callback *completion_callback,
                      const TextBuffer::Snapshot *snapshot,
                      const Regex *regex,
                      const Range &search_range,
@@ -742,7 +742,7 @@ class Loader {
  public:
   bool cancelled;
 
-  Loader(Nan::Callback *progress_callback, Nan::AsyncResource *async_resource,
+  explicit Loader(Nan::Callback *progress_callback, Nan::AsyncResource *async_resource,
          TextBuffer *buffer, TextBuffer::Snapshot *snapshot, string &&file_name,
          string &&encoding_name, bool force, bool compute_patch) :
     progress_callback{progress_callback},
@@ -755,7 +755,7 @@ class Loader {
     compute_patch{compute_patch},
     cancelled{false} {}
 
-  Loader(Nan::Callback *progress_callback, Nan::AsyncResource *async_resource,
+  explicit Loader(Nan::Callback *progress_callback, Nan::AsyncResource *async_resource,
          TextBuffer *buffer, TextBuffer::Snapshot *snapshot, Text &&text,
          bool force, bool compute_patch) :
     progress_callback{progress_callback},
@@ -848,13 +848,13 @@ class LoadWorker : public Nan::AsyncProgressWorkerBase<size_t> {
   Loader loader;
 
  public:
-  LoadWorker(Nan::Callback *completion_callback, Nan::Callback *progress_callback,
+  explicit LoadWorker(Nan::Callback *completion_callback, Nan::Callback *progress_callback,
              TextBuffer *buffer, TextBuffer::Snapshot *snapshot, string &&file_name,
              string &&encoding_name, bool force, bool compute_patch) :
     AsyncProgressWorkerBase(completion_callback, "TextBuffer.load"),
     loader(progress_callback, async_resource, buffer, snapshot, move(file_name), move(encoding_name), force, compute_patch) {}
 
-  LoadWorker(Nan::Callback *completion_callback, Nan::Callback *progress_callback,
+  explicit LoadWorker(Nan::Callback *completion_callback, Nan::Callback *progress_callback,
              TextBuffer *buffer, TextBuffer::Snapshot *snapshot, Text &&text,
              bool force, bool compute_patch) :
     AsyncProgressWorkerBase(completion_callback, "TextBuffer.load"),
@@ -990,7 +990,7 @@ class BaseTextComparisonWorker : public Nan::AsyncWorker {
   bool result;
 
  public:
-  BaseTextComparisonWorker(Nan::Callback *completion_callback, TextBuffer::Snapshot *snapshot,
+  explicit BaseTextComparisonWorker(Nan::Callback *completion_callback, TextBuffer::Snapshot *snapshot,
                        string &&file_name, string &&encoding_name) :
     AsyncWorker(completion_callback, "TextBuffer.baseTextMatchesFile"),
     snapshot{snapshot},
@@ -1050,7 +1050,7 @@ class SaveWorker : public Nan::AsyncWorker {
   optional<Error> error;
 
  public:
-  SaveWorker(Nan::Callback *completion_callback, TextBuffer::Snapshot *snapshot,
+  explicit SaveWorker(Nan::Callback *completion_callback, TextBuffer::Snapshot *snapshot,
              string &&file_name, string &&encoding_name) :
     AsyncWorker(completion_callback, "TextBuffer.save"),
     snapshot{snapshot},

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -78,7 +78,7 @@ class RegexWrapper : public Nan::ObjectWrap {
   static Nan::Persistent<Function> constructor;
   static void construct(const Nan::FunctionCallbackInfo<v8::Value> &info) {}
 
-  RegexWrapper(Regex &&regex) : regex{move(regex)} {}
+  explicit RegexWrapper(Regex &&regex) : regex{move(regex)} {}
 
   static const Regex *regex_from_js(const Local<Value> &value) {
     Local<String> js_pattern;
@@ -137,7 +137,7 @@ class SubsequenceMatchWrapper : public Nan::ObjectWrap {
 public:
   static Nan::Persistent<Function> constructor;
 
-  SubsequenceMatchWrapper(SubsequenceMatch &&match) :
+  explicit SubsequenceMatchWrapper(SubsequenceMatch &&match) :
     match(std::move(match)) {}
 
   static void init() {

--- a/src/bindings/text-writer.h
+++ b/src/bindings/text-writer.h
@@ -8,7 +8,7 @@
 class TextWriter : public Nan::ObjectWrap {
 public:
   static void init(v8::Local<v8::Object> exports);
-  TextWriter(EncodingConversion &&conversion);
+  explicit TextWriter(EncodingConversion &&conversion);
   std::u16string get_text();
 
 private:

--- a/src/core/marker-index.h
+++ b/src/core/marker-index.h
@@ -30,7 +30,7 @@ public:
     std::vector<Boundary> boundaries;
   };
 
-  MarkerIndex(unsigned seed = 0u);
+  explicit MarkerIndex(unsigned seed = 0u);
   ~MarkerIndex();
   int generate_random_number();
   void insert(MarkerId id, Point start, Point end);
@@ -74,7 +74,7 @@ private:
 
   class Iterator {
   public:
-    Iterator(MarkerIndex *marker_index);
+    explicit Iterator(MarkerIndex *marker_index);
     void reset();
     Node* insert_marker_start(const MarkerId &id, const Point &start_position, const Point &end_position);
     Node* insert_marker_end(const MarkerId &id, const Point &start_position, const Point &end_position);

--- a/src/core/patch.cc
+++ b/src/core/patch.cc
@@ -59,7 +59,7 @@ struct Patch::Node {
     compute_subtree_text_sizes();
   }
 
-  Node(Deserializer &input) :
+  explicit Node(Deserializer &input) :
     left{nullptr},
     right{nullptr},
     old_extent{input},

--- a/src/core/patch.cc
+++ b/src/core/patch.cc
@@ -36,7 +36,7 @@ struct Patch::Node {
   uint32_t old_subtree_text_size;
   uint32_t new_subtree_text_size;
 
-  Node(
+  explicit Node(
     Node *left,
     Node *right,
     Point old_extent,

--- a/src/core/patch.h
+++ b/src/core/patch.h
@@ -35,10 +35,10 @@ public:
   };
 
   // Construction and destruction
-  Patch(bool merges_adjacent_changes = true);
   Patch(Patch &&);
-  Patch(Deserializer &input);
   Patch &operator=(Patch &&);
+  explicit Patch(bool merges_adjacent_changes = true);
+  explicit Patch(Deserializer &input);
   ~Patch();
   void serialize(Serializer &serializer);
 

--- a/src/core/point.h
+++ b/src/core/point.h
@@ -14,7 +14,7 @@ struct Point {
 
   Point();
   Point(unsigned row, unsigned column);
-  Point(Deserializer &input);
+  explicit Point(Deserializer &input);
 
   int compare(const Point &other) const;
   bool is_zero() const;

--- a/src/core/regex.h
+++ b/src/core/regex.h
@@ -10,7 +10,7 @@ struct BuildRegexResult;
 
 class Regex {
   pcre2_real_code_16 *code;
-  Regex(pcre2_real_code_16 *);
+  explicit Regex(pcre2_real_code_16 *);
 
  public:
   Regex();
@@ -24,7 +24,7 @@ class Regex {
     friend class Regex;
 
    public:
-    MatchData(const Regex &);
+    explicit MatchData(const Regex & /*regex*/);
     ~MatchData();
   };
 

--- a/src/core/serializer.h
+++ b/src/core/serializer.h
@@ -8,7 +8,7 @@ class Serializer {
   std::vector<uint8_t> &vector;
 
  public:
-  inline Serializer(std::vector<uint8_t> &output) :
+  explicit inline Serializer(std::vector<uint8_t> &output) :
     vector(output) {};
 
   template <typename T>
@@ -25,7 +25,7 @@ class Deserializer {
   const uint8_t *end_ptr;
 
  public:
-  inline Deserializer(const std::vector<uint8_t> &input) :
+  explicit inline Deserializer(const std::vector<uint8_t> &input) :
     read_ptr(input.data()),
     end_ptr(input.data() + input.size()) {};
 

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -32,7 +32,7 @@ struct TextBuffer::Layer {
   uint32_t size_;
   uint32_t snapshot_count;
 
-  Layer(Text &&text) :
+  explicit Layer(Text &&text) :
     previous_layer{nullptr},
     text{move(text)},
     uses_patch{false},
@@ -40,7 +40,7 @@ struct TextBuffer::Layer {
     size_{this->text->size()},
     snapshot_count{0} {}
 
-  Layer(Layer *previous_layer) :
+  explicit Layer(Layer *previous_layer) :
     previous_layer{previous_layer},
     patch{Patch()},
     uses_patch{true},

--- a/src/core/text-buffer.h
+++ b/src/core/text-buffer.h
@@ -21,8 +21,8 @@ public:
   static uint32_t MAX_CHUNK_SIZE_TO_COPY;
 
   TextBuffer();
-  TextBuffer(std::u16string &&);
-  TextBuffer(const std::u16string &text);
+  explicit TextBuffer(std::u16string && /*text*/);
+  explicit TextBuffer(const std::u16string &text);
   ~TextBuffer();
 
   uint32_t size() const;

--- a/src/core/text-slice.h
+++ b/src/core/text-slice.h
@@ -16,8 +16,9 @@ class TextSlice {
   size_t start_offset() const;
   size_t end_offset() const;
 
-  TextSlice();
-  TextSlice(const Text &text);
+  explicit TextSlice();
+  TextSlice(const Text &text); // TODO make it explicit
+
   std::pair<TextSlice, TextSlice> split(Point) const;
   std::pair<TextSlice, TextSlice> split(uint32_t) const;
   TextSlice prefix(Point) const;

--- a/src/core/text.h
+++ b/src/core/text.h
@@ -28,11 +28,11 @@ class Text {
 
   using const_iterator = std::u16string::const_iterator;
 
-  Text();
-  Text(const std::u16string &);
-  Text(std::u16string &&);
-  Text(TextSlice slice);
-  Text(Deserializer &deserializer);
+  explicit Text();
+  explicit Text(const std::u16string & /*string*/);
+  Text(std::u16string && /*content*/); // TODO make it explicit
+  explicit Text(TextSlice slice);
+  explicit Text(Deserializer &deserializer);
   template<typename Iter>
   Text(Iter begin, Iter end) : Text(std::u16string{begin, end}) {}
 


### PR DESCRIPTION
https://github.com/atom/superstring/pull/86

### Description of the change

Make constructors explicit: constructors must be marked explicit to avoid unintentional implicit conversions  [google-explicit-constructor,hicpp-explicit-conversions]

### Verifications 
Tests pass 

### Release Notes 
N/A
